### PR TITLE
feature(rviz_launch_file): RVIZ launch file

### DIFF
--- a/launch/tools/rviz.launch
+++ b/launch/tools/rviz.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<launch>
+
+	<node pkg="rviz" type="rviz" name="$(anon foo)" args="-d $(env ROBOT_BRINGUP_PATH)/parameters/tools/rviz_config.rviz" />
+
+</launch>


### PR DESCRIPTION
Added rviz launch file that points to robot_bringup_path for parameter
loading. This way, we don't have to store the parameters in the tue-env
which is ugly.