### PR TITLE
add dragonfly arg to speech req launch

### DIFF
--- a/launch/interaction/speech_recognition.launch
+++ b/launch/interaction/speech_recognition.launch
@@ -3,6 +3,7 @@
 
 	<!-- Get the machine file -->
 	<arg name="machine" default="localhost"/>
+        <arg name="dragonfly" default="true" />
 	<include file="$(env ROBOT_BRINGUP_PATH)/machines/$(arg machine).machine" />
 
 	<!-- Always run a multicast server with a string topic answerer for amigo-hear -->
@@ -16,9 +17,10 @@
 		<!-- If we are on the real robot, launch the server, otherwise a dummy -->
 		<group if="$(optenv ROBOT_REAL false)">
 			<!-- bridge to windows -->
-			<node name="dragonfly_speech_recognition" pkg="dragonfly_speech_recognition" type="hmi_server_dragonfly_client" machine="$(arg machine)" output="log">
+                        <node name="dragonfly_speech_recognition" pkg="dragonfly_speech_recognition" type="hmi_server_dragonfly_client" machine="$(arg machine)" output="log" if="$(arg dragonfly)" >
 				<rosparam command="load" file="$(env ROBOT_BRINGUP_PATH)/parameters/interaction/speech_client.yaml" />
 			</node>
+                        <!-- Kaldi, when ready-->
 		</group>
 		<group unless="$(optenv ROBOT_REAL false)">
 			<!-- speech dummy -->


### PR DESCRIPTION
add argument to speech recognition file to switch between dragonfly and kaldi.

This file is tabs spaced, but new lines are space spaced, so therefore indent isn't matching.