### PR TITLE
spawn objects from yaml

### DIFF
--- a/launch/simulator/simulator.launch
+++ b/launch/simulator/simulator.launch
@@ -20,13 +20,13 @@
     <node pkg="fast_simulator" type="spawn" name="spawn_world" args="-i $(arg env) -m $(arg env)" output="log"/>
 
     <!-- spawn objects -->
-    <node name="fast_simulator_object_spawner" pkg="fast_simulator_data" type="$(arg env).py" output="log"/>
+    <node name="fast_simulator_object_spawner" pkg="fast_simulator_data" type="spawn_fast_simulator_objects.py" args="worlds/$(arg env)/objects.yaml" output="log"/>
 
     <!-- spawn robot -->
     <node pkg="fast_simulator" type="spawn" name="spawn_robot" args="-i $(arg robot_name) -m $(arg robot_name) -x $(arg robot_init_x) -y $(arg robot_init_y) -Z $(arg robot_init_phi)" output="log"/>
 
     <node pkg="robot_launch_files" type="ssl_dummy" name="ssl">
-		<param name="frame_id" value="$(arg robot_name)/matrix" />
+        <param name="frame_id" value="$(arg robot_name)/matrix" />
     </node>
 
 </launch>


### PR DESCRIPTION
Spawn objects from yaml instead of creating python files for each environment.

Merge with tue-robotics/fast_simulator_data#8